### PR TITLE
getRawSchemalessAttributes() must be of the type array

### DIFF
--- a/src/SchemalessAttributes.php
+++ b/src/SchemalessAttributes.php
@@ -182,7 +182,9 @@ class SchemalessAttributes implements ArrayAccess, Arrayable, Countable, Iterato
 
     protected function getRawSchemalessAttributes(): array
     {
-        return $this->model->fromJson($this->model->getAttributes()[$this->sourceAttributeName] ?? '{}');
+        $attributes = $this->model->getAttributes()[$this->sourceAttributeName] ?? '{}';
+
+        return ($attributes =='""' ? [] : $this->model->fromJson($attributes));
     }
 
     protected function override(iterable $collection)


### PR DESCRIPTION
Fixes issue #45 getRawSchemalessAttributes() must be of the type array, string returned on Postgresql which returns a string object rather than an array when null stored in SchemalessAttributes, including StyleCI fixes